### PR TITLE
terraform(NAT Gateway)の追加

### DIFF
--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -139,3 +139,36 @@ resource "aws_route" "public_rt_igw_r" {
   destination_cidr_block = var.igw_address
   gateway_id             = aws_internet_gateway.igw.id
 }
+
+# ---------------------------------------------
+# NAT Gateway
+# ---------------------------------------------
+resource "aws_nat_gateway" "nat_gw" {
+  allocation_id     = aws_eip.nat_eip.id
+  subnet_id         = aws_subnet.public_subnet_1a.id
+  connectivity_type = "public"
+
+  tags = {
+    Name    = "${var.project}-${var.environment}-nat-gateway"
+    Project = var.project
+    Env     = var.environment
+  }
+}
+
+resource "aws_route" "private_rt_natgw" {
+  route_table_id         = aws_route_table.private_rt.id
+  destination_cidr_block = var.igw_address
+  nat_gateway_id         = aws_nat_gateway.nat_gw.id
+}
+
+
+# ---------------------------------------------
+# Elastic IP（EIP）
+# ---------------------------------------------
+resource "aws_eip" "nat_eip" {
+  tags = {
+    Name    = "${var.project}-${var.environment}-nat-eip"
+    Project = var.project
+    Env     = var.environment
+  }
+}

--- a/terraform/security_group.tf
+++ b/terraform/security_group.tf
@@ -41,6 +41,16 @@ resource "aws_security_group_rule" "app_runner_out_internet" {
   cidr_blocks       = [var.igw_address]
 }
 
+resource "aws_security_group_rule" "app_runner_out_supabase" {
+  security_group_id = aws_security_group.app_runner_sg.id
+  type              = "egress"
+  protocol          = "tcp"
+  from_port         = var.supabase_port
+  to_port           = var.supabase_port
+  cidr_blocks       = [var.igw_address]
+  description       = "Allow outbound traffic to Supabase PostgreSQL on port 6543"
+}
+
 # ElastiCache Security Group
 resource "aws_security_group" "elasticache_sg" {
   name        = "${var.project}-${var.environment}-elasticache-sg"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -45,6 +45,10 @@ variable "redis_port" {
   type = number
 }
 
+variable "supabase_port" {
+  type = number
+}
+
 variable "supabase_url" {
   type = string
 }


### PR DESCRIPTION
# [現象]
AWSのアーキテクチャを構築したが、Supabaseに接続できず、
App Runnerの構築に失敗していた。

# [原因]
- publicサブネットにApp Runnerを構築していたが、
   App Runner -> ElastiCacheへの接続の為、VPC Connectorを付与していた。
   その影響でApp Runnerがprivateサブネット側に設置されていた。

# [解消]
- NAT Gatewayを付与することでprivateサブネットからインターネットへ接続できるようにした。